### PR TITLE
Vendor pyhumps; camelize and decamelize

### DIFF
--- a/openaq/shared/responses.py
+++ b/openaq/shared/responses.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from types import ModuleType
 from typing import Any, Dict, List, Tuple, Union
 
-from humps import camelize, decamelize
+from openaq.utils.humps import camelize, decamelize
 
 try:
     import orjson

--- a/openaq/utils/humps.py
+++ b/openaq/utils/humps.py
@@ -1,0 +1,60 @@
+# This implementation of camelize and decamelize functions is adapted from the humps library by Nick Ficano.
+# Original source: https://github.com/nficano/humps
+# The humps library is used for converting strings into different naming conventions (e.g., camelCase, PascalCase, snake_case).
+# Thanks to Nick Ficano for the original implementation.
+
+import re
+
+from collections.abc import Mapping
+
+ACRONYM_RE = re.compile(r"([A-Z\d]+)(?=[A-Z\d]|$)")
+PASCAL_RE = re.compile(r"([^\-_]+)")
+SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9])(?=[A-Z])[^A-Z]*[\-_]*)")
+UNDERSCORE_RE = re.compile(r"(?<=[^\-_])[\-_]+[^\-_]")
+
+
+def camelize(str_or_iter):
+    """
+    Convert a string, dict, or list of dicts to camel case.
+
+    :param str_or_iter:
+        A string or iterable.
+    :type str_or_iter: Union[list, dict, str]
+    :rtype: Union[list, dict, str]
+    :returns:
+        camelized string, dictionary, or list of dictionaries.
+    """
+    if isinstance(str_or_iter, (list, Mapping)):
+        return _process_keys(str_or_iter, camelize)
+
+    s = _is_none(str_or_iter)
+    if s.isupper() or s.isnumeric():
+        return str_or_iter
+
+    if len(s) != 0 and not s[:2].isupper():
+        s = s[0].lower() + s[1:]
+
+    # For string "hello_world", match will contain
+    #             the regex capture group for "_w".
+    return UNDERSCORE_RE.sub(lambda m: m.group(0)[-1].upper(), s)
+
+
+def decamelize(str_or_iter):
+    """
+    Convert a string, dict, or list of dicts to snake case.
+
+    :param str_or_iter:
+        A string or iterable.
+    :type str_or_iter: Union[list, dict, str]
+    :rtype: Union[list, dict, str]
+    :returns:
+        snake cased string, dictionary, or list of dictionaries.
+    """
+    if isinstance(str_or_iter, (list, Mapping)):
+        return _process_keys(str_or_iter, decamelize)
+
+    s = _is_none(str_or_iter)
+    if s.isupper() or s.isnumeric():
+        return str_or_iter
+
+    return _separate_words(_fix_abbreviations(s)).lower()

--- a/openaq/utils/humps.py
+++ b/openaq/utils/humps.py
@@ -1,7 +1,11 @@
-# This implementation of camelize and decamelize functions is adapted from the humps library by Nick Ficano.
-# Original source: https://github.com/nficano/humps
-# The humps library is used for converting strings into different naming conventions (e.g., camelCase, PascalCase, snake_case).
-# Thanks to Nick Ficano for the original implementation.
+"""
+This module is a vendored version of the 'humps' package originally found at:
+https://github.com/nficano/humps
+
+The original package is licensed under the "Unlicense", a public domain equivalent license.
+For more details, see: https://github.com/nficano/humps/blob/master/LICENSE
+Thanks to Nick Ficano for the original implementation.
+"""
 
 import re
 

--- a/openaq/utils/humps.py
+++ b/openaq/utils/humps.py
@@ -7,9 +7,6 @@ import re
 
 from collections.abc import Mapping
 
-ACRONYM_RE = re.compile(r"([A-Z\d]+)(?=[A-Z\d]|$)")
-PASCAL_RE = re.compile(r"([^\-_]+)")
-SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9])(?=[A-Z])[^A-Z]*[\-_]*)")
 UNDERSCORE_RE = re.compile(r"(?<=[^\-_])[\-_]+[^\-_]")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx==0.25.0", "pyhumps==3.8.0"]
+dependencies = ["httpx==0.25.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
closes #3 
Solves the need to import pyhumps. Attribution is made to the original author in `openaq/utils/humps.py`