### PR TITLE
Fix: deserialize ignores new fields

### DIFF
--- a/openaq/shared/responses.py
+++ b/openaq/shared/responses.py
@@ -71,7 +71,13 @@ class _ResponseBase:
         Returns:
             Deserialized representation of the response data as a Python object.
         """
-        return cls(**cls._deserialize(data))
+        deserialized_data = cls._deserialize(data)
+
+        # Filter out fields that are not in the class annotations
+        expected_fields = {
+            k: v for k, v in deserialized_data.items() if k in cls.__annotations__
+        }
+        return cls(**expected_fields)
 
     def dict(self) -> Dict:
         """Serializes response data to Python dictionary.

--- a/tests/test_shared_responses.py
+++ b/tests/test_shared_responses.py
@@ -92,11 +92,11 @@ def test_response_ignores_unexpected_fields(
     base_response = read_response_file('locations')
     base_json = json.loads(base_response)
 
-    additional_json = json.loads(extra_field)
-    modified_json = base_json['results'][0].update(additional_json)
+    modified_json = json.loads(extra_field)
+    base_json['results'][0].update(modified_json)
 
     try:
-        response_instance = response_class.load(modified_json)
+        response_instance = response_class.load(base_json)
         assert not hasattr(
             response_instance.results[0], 'anotherField'
         ), "Unexpected 'anotherField' was not ignored"


### PR DESCRIPTION
This introduces a modification to the deserialization logic within the Python client to gracefully handle unexpected fields in the API responses. As we've observed the current implementation raises a TypeError when it encounters any unexpected keyword arguments during the initialization of response objects. 

This approach leverages the class's __annotations__ attribute, which contains a dictionary of expected fields based on type annotations. We can filter for fields that match the annotations.

I have also included a test in `tests/test_shared_responses.py` to ensure that it functions as expected.