### PR TITLE
Sensors endpoints

### DIFF
--- a/openaq/_async/client.py
+++ b/openaq/_async/client.py
@@ -10,6 +10,8 @@ from openaq._async.models.measurements import Measurements
 from openaq._async.models.owners import Owners
 from openaq._async.models.parameters import Parameters
 from openaq._async.models.providers import Providers
+from openaq._async.models.sensors import Sensors
+
 from openaq.shared.client import (
     DEFAULT_USER_AGENT,
     BaseClient,
@@ -70,6 +72,7 @@ class AsyncOpenAQ(BaseClient):
         self.manufacturers = Manufacturers(self)
         self.measurements = Measurements(self)
         self.owners = Owners(self)
+        self.sensors = Sensors(self)
 
     @property
     def transport(self) -> AsyncTransport:

--- a/openaq/_async/models/sensors.py
+++ b/openaq/_async/models/sensors.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from openaq.shared.responses import SensorsResponse
+
+from .base import AsyncResourceBase
+
+
+class Sensors(AsyncResourceBase):
+    """This provides methods to retrieve sensor data from the OpenAQ API."""
+
+    async def get(self, sensors_id: int) -> SensorsResponse:
+        """Retrieve a specific sensor by its ID.
+
+        Args:
+            sensors_id: The ID of the sensor to retrieve.
+
+        Returns:
+            SensorsResponse: An instance representing the retrieved sensor.
+        """
+        sensor = await self._client._get(f"/sensors/{sensors_id}")
+        return SensorsResponse.load(sensor.json())
+
+    async def list(self, locations_id: int) -> SensorsResponse:
+        """Retrieve sensors for a specific location by its ID.
+
+        Args:
+            locations_id: The ID of the location to retrieve sensors for.
+
+        Returns:
+            SensorsResponse: An instance representing the sensors associated with the location.
+        """
+        sensors = await self._client._get(f"/locations/{locations_id}/sensors")
+        return SensorsResponse.load(sensors.json())

--- a/openaq/_sync/client.py
+++ b/openaq/_sync/client.py
@@ -10,6 +10,8 @@ from openaq._sync.models.measurements import Measurements
 from openaq._sync.models.owners import Owners
 from openaq._sync.models.parameters import Parameters
 from openaq._sync.models.providers import Providers
+from openaq._sync.models.sensors import Sensors
+
 from openaq.shared.client import (
     DEFAULT_USER_AGENT,
     BaseClient,
@@ -70,6 +72,7 @@ class OpenAQ(BaseClient):
         self.manufacturers = Manufacturers(self)
         self.measurements = Measurements(self)
         self.owners = Owners(self)
+        self.sensors = Sensors(self)
 
     @property
     def transport(self) -> Transport:

--- a/openaq/_sync/models/sensors.py
+++ b/openaq/_sync/models/sensors.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from openaq.shared.responses import SensorsResponse
+
+from .base import SyncResourceBase
+
+
+class Sensors(SyncResourceBase):
+    """This provides methods to retrieve sensor data from the OpenAQ API."""
+
+    def get(self, sensors_id: int) -> SensorsResponse:
+        """Retrieve a specific sensor by its ID.
+
+        Args:
+            sensors_id: The ID of the sensor to retrieve.
+
+        Returns:
+            SensorsResponse: An instance representing the retrieved sensor.
+        """
+        sensor = self._client._get(f"/sensors/{sensors_id}")
+        return SensorsResponse.load(sensor.json())
+
+    def list(self, locations_id: int) -> SensorsResponse:
+        """Retrieve sensors for a specific location by its ID.
+
+        Args:
+            location_id: The ID of the location to retrieve sensors for.
+
+        Returns:
+            SensorsResponse: An instance representing the sensors associated with the location.
+        """
+        sensors = self._client._get(f"/locations/{locations_id}/sensors")
+        return SensorsResponse.load(sensors.json())

--- a/openaq/shared/responses.py
+++ b/openaq/shared/responses.py
@@ -347,6 +347,81 @@ class LocationsResponse(_ResponseBase):
             self.results = [Location.load(x) for x in self.results]
 
 
+# Sensors
+
+
+@dataclass
+class SensorLatest(_ResponseBase):
+    """Represents the latest measurement from a sensor in OpenAQ.
+
+    Attributes:
+        datetime (Datetime): The datetime of the latest measurement.
+        value (float): The value of the latest measurement.
+        coordinates (Coordinates): The geographic coordinates of the sensor when the measurement was taken.
+    """
+
+    datetime: Datetime
+    value: float
+    coordinates: Coordinates
+
+
+@dataclass
+class Sensor(_ResponseBase):
+    """Represents a sensor in OpenAQ, including its measurement details and metadata.
+
+    Attributes:
+        id (int): Unique identifier for the sensor.
+        name (str): Name of the sensor.
+        parameter (Parameter): The measurement parameter associated with the sensor.
+        datetime_first (Datetime): The datetime of the first measurement recorded by the sensor.
+        datetime_last (Datetime): The datetime of the last measurement recorded by the sensor.
+        coverage (Coverage): Coverage details for the sensor's measurements.
+        latest (SensorLatest): The latest measurement recorded by the sensor.
+        summary (SensorSummary): A summary of the sensor's measurement values.
+
+    Methods:
+        __post_init__: Initializes complex types from the raw response data.
+    """
+
+    id: int
+    name: str
+    parameter: Parameter
+    datetime_first: Datetime
+    datetime_last: Datetime
+    coverage: Coverage
+    latest: SensorLatest
+    summary: Summary
+
+    def __post_init__(self):
+        """Sets class attributes to correct type after checking input type."""
+        self.parameter = Parameter.load(self.parameter)
+        self.datetime_first = Datetime.load(self.datetime_first)
+        self.datetime_last = Datetime.load(self.datetime_last)
+        self.coverage = Coverage.load(self.coverage)
+        self.latest = SensorLatest.load(self.latest)
+        self.summary = Summary.load(self.summary)
+
+
+@dataclass
+class SensorsResponse(_ResponseBase):
+    """Represents a response containing a list of sensors from the OpenAQ API.
+
+    Attributes:
+        meta (Meta): Metadata about the response, such as pagination details.
+        results (List[Sensor]): A list of sensors.
+
+    Methods:
+        __post_init__: Initializes the list of sensors from the raw response data.
+    """
+
+    meta: Meta
+    results: List[Sensor]
+
+    def __post_init__(self):
+        """Sets class attributes to correct type after checking input type."""
+        self.results = [Sensor.load(x) for x in self.results]
+
+
 # Providers
 
 

--- a/openaq/shared/responses.py
+++ b/openaq/shared/responses.py
@@ -355,9 +355,9 @@ class SensorLatest(_ResponseBase):
     """Represents the latest measurement from a sensor in OpenAQ.
 
     Attributes:
-        datetime (Datetime): The datetime of the latest measurement.
-        value (float): The value of the latest measurement.
-        coordinates (Coordinates): The geographic coordinates of the sensor when the measurement was taken.
+        datetime: The datetime of the latest measurement.
+        value: The value of the latest measurement.
+        coordinates: The geographic coordinates of the sensor when the measurement was taken.
     """
 
     datetime: Datetime
@@ -370,14 +370,14 @@ class Sensor(_ResponseBase):
     """Represents a sensor in OpenAQ, including its measurement details and metadata.
 
     Attributes:
-        id (int): Unique identifier for the sensor.
-        name (str): Name of the sensor.
-        parameter (Parameter): The measurement parameter associated with the sensor.
-        datetime_first (Datetime): The datetime of the first measurement recorded by the sensor.
-        datetime_last (Datetime): The datetime of the last measurement recorded by the sensor.
-        coverage (Coverage): Coverage details for the sensor's measurements.
-        latest (SensorLatest): The latest measurement recorded by the sensor.
-        summary (SensorSummary): A summary of the sensor's measurement values.
+        id: Unique identifier for the sensor.
+        name: Name of the sensor.
+        parameter: The measurement parameter associated with the sensor.
+        datetime_first: The datetime of the first measurement recorded by the sensor.
+        datetime_last: The datetime of the last measurement recorded by the sensor.
+        coverage: Coverage details for the sensor's measurements.
+        latest: The latest measurement recorded by the sensor.
+        summary: A summary of the sensor's measurement values.
 
     Methods:
         __post_init__: Initializes complex types from the raw response data.
@@ -407,8 +407,8 @@ class SensorsResponse(_ResponseBase):
     """Represents a response containing a list of sensors from the OpenAQ API.
 
     Attributes:
-        meta (Meta): Metadata about the response, such as pagination details.
-        results (List[Sensor]): A list of sensors.
+        meta: Metadata about the response, such as pagination details.
+        results: A list of sensors.
 
     Methods:
         __post_init__: Initializes the list of sensors from the raw response data.


### PR DESCRIPTION
Adds response objects for `sensors` and add `get` and `list` methods to access a list of sensors by `locations_id` or get data on one sensor with `sensors_id`.

uses endpoints `/locations/{locations_id}/sensors` and  `/sensors/{sensors_id}`, respectively.

Example usage:
`client.sensors.list(2178)`
`client.sensors.get(3916)`
  
closes #8