### PR TITLE
Fixing errors in the logic of requesting measurements to the real server

### DIFF
--- a/openaq/_async/models/measurements.py
+++ b/openaq/_async/models/measurements.py
@@ -18,7 +18,7 @@ class Measurements(AsyncResourceBase):
         sensors_id: int,
         data: Union[Data, None] = None,
         rollup: Union[Rollup, None] = None,
-        date_from: Union[datetime.datetime, str, None] = "2016-10-10",
+        date_from: Union[datetime.datetime, str, None] = "2016-10-10T00:00:00Z",
         date_to: Union[datetime.datetime, str, None] = None,
         page: int = 1,
         limit: int = 1000,

--- a/openaq/_sync/models/measurements.py
+++ b/openaq/_sync/models/measurements.py
@@ -18,7 +18,7 @@ class Measurements(SyncResourceBase):
         sensors_id: int,
         data: Union[Data, None] = None,
         rollup: Union[Rollup, None] = None,
-        datetime_from: Union[datetime.datetime, str, None] = "2016-10-10",
+        datetime_from: Union[datetime.datetime, str, None] = "2016-10-10T00:00:00Z",
         datetime_to: Union[datetime.datetime, str, None] = None,
         page: int = 1,
         limit: int = 1000,

--- a/tests/unit/sync/test_sync_resources.py
+++ b/tests/unit/sync/test_sync_resources.py
@@ -42,7 +42,7 @@ def test_measurements_list_endpoints(
     mock_response = Mock()
     MeasurementsResponse.read_response = Mock(return_value=mock_response)
     mock_client._get.return_value = mock_response
-    mock_params = {'page': 1, 'limit': 1000, 'datetime_from': '2016-10-10'}
+    mock_params = {'page': 1, 'limit': 1000, 'datetime_from': '2016-10-10T00:00:00Z'}
     mocker.patch('openaq.shared.models.build_query_params', return_value=mock_params)
     measurements.list(sensors_id=1, data=data, rollup=rollup)
 


### PR DESCRIPTION
### What has been done:
- Fixed errors in the **list()** method of the **Measurements** class in **_async** and **_sync**, which caused crashes when calling the **list()** method without specifying **date_from**.
- Fixed the test case for the **list()** method: checking whether the **list()** method was called successfully without specifying **date_from**.

### Tests:
All [**hatch run test:cov**] tests pass successfully.

### Why this is important:
These changes allow the **list()** method of the **Measurements** class to be used without specifying **date_from** when querying the real server. Previously, this would result in an error: **500 Internal Server Error**.

### How to replicate this error:
To test and replicate this error, you can use the following code:
```python
from openaq import OpenAQ
from pprint import pprint
import datetime

client = OpenAQ(api_key='YOUR_API_KEY')

locations = client.locations.list(coordinates=(39.904211,116.407395), radius=10_000)  # Beijin

sensor_id = locations.results[0].sensors[0].id  # id=40 - One from Beijin
sensor = client.sensors.get(sensor_id)

measurements = client.measurements.list(40, limit=100)  # ERROR: "openaq.shared.exceptions.ServerError: Internal Server Error"
pprint(measurements)

client.close()
```