### PR TITLE
add caching to ResourceBase deserialize

### DIFF
--- a/openaq/shared/responses.py
+++ b/openaq/shared/responses.py
@@ -48,7 +48,7 @@ class _ResourceBase:
         out: dict[str, Any] = {}
         for k, v in data.items():
             if k not in _DECAMELIZE_CACHE:
-                _DECAMELIZE_CACHE[k] = decamelize(k)
+                _DECAMELIZE_CACHE[k] = cast(str, decamelize(k))
             key = _DECAMELIZE_CACHE[k]
             if isinstance(v, dict):
                 out[key] = cls._deserialize(v)


### PR DESCRIPTION
Caches decamelize operation on _ResourceBase deserialize method. Improves loading performance 4x, reducing redundant calls.  A benchmark test to compare the previous commit (which includes slots for dataclasses) vs this change:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Implementation                 ┃ Avg. Speed ┃  Throughput ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ Original                       │   70.26 μs │ 14233 ops/s │
│ Slots + _DECAMELIZE_CACHE      │   17.11 μs │ 58444 ops/s │
└────────────────────────────────┴────────────┴─────────────┘
```